### PR TITLE
Separate dev, prod settings

### DIFF
--- a/train2/data/analysis/data_utils.py
+++ b/train2/data/analysis/data_utils.py
@@ -1,7 +1,7 @@
 import os
 import sys
 sys.path.append('../')
-os.environ['DJANGO_SETTINGS_MODULE'] = "train2.settings"
+os.environ['DJANGO_SETTINGS_MODULE'] = os.getenv('DJANGO_SETTINGS_MODULE', 'train2.settings.dev_settings')
 import datetime
 import django
 django.setup()

--- a/train2/manage.py
+++ b/train2/manage.py
@@ -3,7 +3,8 @@ import os
 import sys
 
 if __name__ == "__main__":
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "train2.settings")
+    env_or_default_settings = os.getenv('DJANGO_SETTINGS_MODULE', 'train2.settings.dev_settings')
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', env_or_default_settings)
 
     from django.core.management import execute_from_command_line
 

--- a/train2/train2/settings/common_settings.py
+++ b/train2/train2/settings/common_settings.py
@@ -24,9 +24,6 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = 'ei1vd+bsrw(vf!-c(8h_t^z%jm0k)&l!2s21cl8tl=pou0nq^g'
 
-# SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
-
 ALLOWED_HOSTS = ['*']
 
 # Application definition

--- a/train2/train2/settings/dev_settings.py
+++ b/train2/train2/settings/dev_settings.py
@@ -1,0 +1,3 @@
+from .common_settings import *
+DEBUG = True
+

--- a/train2/train2/settings/prod_settings.py
+++ b/train2/train2/settings/prod_settings.py
@@ -1,0 +1,2 @@
+from .common_settings import *
+DEBUG = False

--- a/train2/train2/wsgi.py
+++ b/train2/train2/wsgi.py
@@ -10,7 +10,7 @@ https://docs.djangoproject.com/en/1.9/howto/deployment/wsgi/
 import os
 
 from django.core.wsgi import get_wsgi_application
-
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "train2.settings")
+env_or_default_settings = os.getenv('DJANGO_SETTINGS_MODULE', 'train2.settings.dev_settings')
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', env_or_default_settings)
 
 application = get_wsgi_application()


### PR DESCRIPTION
Initial commit for cleanly separating dev, prod settings.
Default `python manage.py runserver` should run with dev settings
Prod should have
`export DJANGO_SETTINGS_MODULE=train2.prod_settings`
this can be placed in the virtual environment's post-activate hook or as part of the hosting system's management of environment variables...