### PR TITLE
Hide top highlights

### DIFF
--- a/train2/data/api.py
+++ b/train2/data/api.py
@@ -303,7 +303,7 @@ class HighlightsViewSet(ViewSet):
             'url': static('analysis/routes_output.xlsx')
         })
 
-    @list_route()
+    # @list_route()
     def top(self, request, *args, **kwargs):
         path = os.path.join(settings.BASE_DIR, "analysis/static/analysis/manual_highlights.json")
         with open(path) as fh:

--- a/train2/ui/static/ui/RouteExplorer/js/RouteExplorer.js
+++ b/train2/ui/static/ui/RouteExplorer/js/RouteExplorer.js
@@ -68,13 +68,13 @@
                     reloadOnSearch: false,
                     resolve: {'Layout': 'Layout'},
                 })
-                .when("/top-highlights", {
-                    pageId: 'top_highlights',
-                    templateUrl: templateUrl('TopHighlights'),
-                    controller: 'TopHighlightsController',
-                    reloadOnSearch: false,
-                    resolve: {'Layout': 'Layout'},
-                })
+                // .when("/top-highlights", {
+                //     pageId: 'top_highlights',
+                //     templateUrl: templateUrl('TopHighlights'),
+                //     controller: 'TopHighlightsController',
+                //     reloadOnSearch: false,
+                //     resolve: {'Layout': 'Layout'},
+                // })
                 .when("/trip-details", {
                     pageId: 'trip_details',
                     templateUrl: templateUrl('TripDetails'),

--- a/train2/ui/templates/ui/RouteExplorer.html
+++ b/train2/ui/templates/ui/RouteExplorer.html
@@ -62,9 +62,9 @@
                         <li>
                             <a href="/#highlights">Highlights</a>
                         </li>
-                        <li>
+                        <!--<li>
                             <a href="/#top-highlights">Top Highlights</a>
-                        </li>
+                        </li>-->
                         <li>
                             <a href="/#graphs">גרפים</a>
                         </li>


### PR DESCRIPTION
Top highlights currently only contains filler text; page should be developed on side branch and merged when ready. At very least should be not accessible to user.

![image](https://user-images.githubusercontent.com/1482729/42047890-44e92218-7b0a-11e8-943f-cfcd24a9e922.png)
