### PR TITLE
Route serializer uses stop_id, not gtfs_stop_id; fixes info/routes page

### DIFF
--- a/train2/info/views.py
+++ b/train2/info/views.py
@@ -34,7 +34,7 @@ def get_old_routes():
     assert len(all_routes) == size
     result = [{
                   'id': route['id'],
-                  'stop_ids': [s['gtfs_stop_id'] for s in route['stops']]
+                  'stop_ids': [s['stop_id'] for s in route['stops']]
               } for route in all_routes]
     assert len(result) == size
     return result


### PR DESCRIPTION
Currently
http://otrain.org/info/routes/
is broken. This fixes it.

Current state:

![image](https://user-images.githubusercontent.com/1482729/42048009-99835d34-7b0a-11e8-9e13-f06f66af13a0.png)


Fixed (though processing of the page takes a long time):

![image](https://user-images.githubusercontent.com/1482729/42048049-bb8238c4-7b0a-11e8-9809-c9a094545fb2.png)
