### PR TITLE
Text labels for trip-details page

### DIFF
--- a/train2/ui/static/ui/RouteExplorer/tpls/TripDetails.html
+++ b/train2/ui/static/ui/RouteExplorer/tpls/TripDetails.html
@@ -36,9 +36,33 @@
                         <td>תאריך</td>
                         <td>{{ trip.date }}</td>
                     </tr>
-                    <tr ng-repeat="field in x_fields">
-                        <td>{{ field }}</td>
-                        <td>{{ trip[field] }}</td>
+		    <tr>
+                        <td>יום בשבוע</td>
+                        <td>{{ trip.x_week_day_local }}</td>
+                    </tr>
+		    <tr>
+                        <td>שעה</td>
+                        <td>{{ trip.x_hour_local }}</td>
+                    </tr>
+		    <tr>
+                        <td>איחור מרבי</td>
+                        <td>{{ trip.x_max_delay_arrival }}</td>
+                    </tr>
+		    <tr>
+                        <td>איחור שני בגודלו</td>
+                        <td>{{ trip.x_max2_delay_arrival }}</td>
+                    </tr>
+		    <tr>
+                        <td>איחור ממוצע</td>
+                        <td>{{ trip.x_avg_delay_arrival }}</td>
+                    </tr>
+		    <tr>
+                        <td>איחור אחרון</td>
+                        <td>{{ trip.x_last_delay_arrival }}</td>
+                    </tr>
+		    <tr>
+                        <td>איחור לפני אחרון</td>
+                        <td>{{ trip.x_before_last_delay_arrival }}</td>
                     </tr>
                 </table>
             </div>


### PR DESCRIPTION
For instance, http://192.168.169.128:8000/#/trip-details?trip_id=10 leads to

![image](https://user-images.githubusercontent.com/1482729/42048160-11585486-7b0b-11e8-966b-3c58f7b6e8e5.png)

with this fix

![image](https://user-images.githubusercontent.com/1482729/42048213-4107adbc-7b0b-11e8-99ef-2d6c375bf867.png)
