### PR TITLE
Fix select route title typo

### DIFF
--- a/train2/ui/app/src/scss/_select-route.scss
+++ b/train2/ui/app/src/scss/_select-route.scss
@@ -22,7 +22,7 @@ body.rex-page-routes {
         }
     }
 
-    .select-route-titel{
+    .select-route-title{
     margin-bottom: 30px;
     margin-top: 0;
     font-size: 26px;


### PR DESCRIPTION
css class name incorrect (the HTML file was using the correct name; the CSS file was using the incorrect name so i reality it was never being used...)